### PR TITLE
fix: Plus 检测忽略 SOCKS5 代理，强制使用 HTTP 代理

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -765,8 +765,19 @@ def api_check_plus(req: CheckPlusReq):
         try:
             proxies = None
             proxy = req.proxy.strip()
-            if proxy:
+            # 检测 chatgpt.com 必须用 HTTP 代理（SOCKS5 对 chatgpt.com 有 TLS 问题）。
+            # 表单 proxy 是注册/跑号共用的 SOCKS5，会连不上 —— 检测这里强制走 DB 配置的
+            # check_plus_proxy（默认 sing-box HTTP 7890），不信任前端传来的 SOCKS5。
+            from . import db as _db
+            proxy = req.proxy.strip()
+            if proxy and not proxy.startswith("socks"):
                 proxies = {"https": proxy, "http": proxy}
+            else:
+                _proxy = _db.get_setting("check_plus_proxy", "")
+                if _proxy and not _proxy.startswith("socks"):
+                    proxies = {"https": _proxy, "http": _proxy}
+                else:
+                    proxies = {"https": "http://127.0.0.1:7890", "http": "http://127.0.0.1:7890"}
             resp = cffi_requests.get(
                 "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27",
                 headers={


### PR DESCRIPTION
## 问题

前端表单的 `proxy` 字段被「单次注册 / 全自动批量 / Plus 检测」三处共用。注册跑号常用 SOCKS5（hysteria2），但 **SOCKS5 连 chatgpt.com 有 TLS 兼容问题**（`curl: (35) TLS connect error: invalid library`），导致 Plus 检测接口静默失败：

- 后端 `except Exception: pass` 吞掉所有异常，无任何报错
- 前端收到空结果，显示 `完成: 0 可用Plus, 0 Free, 0 封号`，表现为「秒返回无效果」

## 修复

`/api/registered/check_plus` 在收到 `socks://` / `socks5://` 开头的代理时**自动忽略**，改用 DB 配置 `check_plus_proxy`：

- 优先读 settings 表 `check_plus_proxy`（管理员可配）
- 未配置时回退到 `http://127.0.0.1:7890`（sing-box HTTP 代理）
- 前端传非 socks 代理时仍尊重用户配置

## 验证

- 传 `socks5://127.0.0.1:1081` → 后端改用 HTTP 代理，返回 `Free` ✅
- 传 `http://127.0.0.1:7890` → 正常返回结果 ✅
- 传空代理 → 回退默认 HTTP 代理 ✅