### PR TITLE
feat: 新增补 refresh 功能，为无 refresh_token 的号重新跑注册

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(ROOT))
 
 from . import db, export_formats, registrar  # noqa: E402
 from .auto_loop import CONTROLLER as AUTO_LOOP  # noqa: E402
+from .proxy_health import get_checker as get_proxy_health_checker  # noqa: E402
 from mail_providers import (  # noqa: E402
     ImportValidationError,
     MailProviderError,
@@ -42,6 +43,12 @@ try:
         logging.getLogger("webui").info(f"[startup] 释放 {_released} 个卡死的 in_use 号")
 except Exception as _e:
     logging.getLogger("webui").warning(f"[startup] release_stale 失败: {_e}")
+
+# 启动代理池健康检查后台线程（每 5 分钟自动检测一次）
+try:
+    get_proxy_health_checker().start()
+except Exception as _e:
+    logging.getLogger("webui").warning(f"[startup] 代理健康检查启动失败: {_e}")
 
 logging.basicConfig(
     level=logging.INFO,
@@ -181,6 +188,11 @@ def api_stats():
     return {"ok": True, "stats": db.stats()}
 
 
+@app.get("/api/stats/detailed")
+def api_stats_detailed():
+    return {"ok": True, "stats": db.get_detailed_stats()}
+
+
 # ──────────────────────── 代理连通性测试 ────────────────────────
 
 
@@ -240,6 +252,57 @@ def api_proxy_test(req: ProxyTestReq):
         for proxy, res in zip(proxies, ex.map(_test_one, proxies)):
             results[proxy] = res
     return {"ok": True, "results": results}
+
+
+# ──────────────────────── 代理池同步 + 健康状态 ────────────────────────
+
+
+class ProxyPoolSyncReq(BaseModel):
+    proxies: list[str] = Field(default_factory=list, description="代理池列表")
+
+
+@app.post("/api/proxy/pool")
+def api_proxy_pool_sync(req: ProxyPoolSyncReq):
+    """前端同步代理池到后端，供定时健康检查使用。
+
+    前端每次修改代理池后调用，保证后端定时任务测试的是「当前生效」的池。
+    """
+    db.set_proxy_pool(req.proxies)
+    return {"ok": True, "count": len(req.proxies)}
+
+
+@app.get("/api/proxy/health")
+def api_proxy_health():
+    """返回各代理的健康状态（含绿色/红色指示，前端仪表盘用）。
+
+    返回结构：
+        {
+            "ok": True,
+            "proxies": { "proxy_string": { "ok": bool, "latency_ms": int, ... } },
+            "last_check_at": float,
+            "healthy": int,
+            "unhealthy": int,
+            "removed": list[str],
+            "removed_count": int,
+            "total": int,
+            "checker_status": { "running": bool, "in_progress": bool, ... },
+        }
+    """
+    health = db.get_proxy_health()
+    checker = get_proxy_health_checker()
+    return {
+        "ok": True,
+        **health,
+        "checker_status": checker.get_status(),
+    }
+
+
+@app.post("/api/proxy/health/check")
+def api_proxy_health_check():
+    """手动触发一次代理健康检查。"""
+    checker = get_proxy_health_checker()
+    result = checker.check_now()
+    return {"ok": True, **result}
 
 
 @app.post("/api/register")
@@ -352,6 +415,17 @@ def api_registered(limit: int = 20, offset: int = 0, filter: str = "all"):
     items = db.list_registered(limit=limit, offset=offset, filter_rt=filter)
     total = db.count_registered(filter_rt=filter)
     return {"ok": True, "items": items, "total": total}
+
+
+@app.get("/api/registered/without_refresh")
+def api_registered_without_refresh():
+    """返回 registered 表中无 refresh_token 的号（email 列表）。
+
+    ⚠️ 必须定义在 /api/registered/{email} 之前，
+      否则 FastAPI 会把 without_refresh 当 email 参数匹配，永远 404。
+    """
+    emails = db.get_accounts_without_refresh()
+    return {"ok": True, "emails": emails, "count": len(emails)}
 
 
 @app.get("/api/registered/{email}")
@@ -832,6 +906,96 @@ def api_check_plus(req: CheckPlusReq):
             db.update_plus_check(email, {**info, "checked_at": checked_at})
 
     return {"ok": True, "results": results}
+
+
+# ──────────────────────── 补 refresh（无 refresh_token 的号重跑注册） ────────────────────────
+
+
+    return {"ok": True, "emails": emails, "count": len(emails)}
+
+
+class RefreshRefreshReq(BaseModel):
+    emails: list[str] = Field(..., description="要补 refresh 的邮箱列表")
+    proxy: str = Field("", description="注册用代理，留空直连")
+    otp_timeout: int = Field(10, description="接码超时秒数")
+
+
+@app.post("/api/registered/refresh_refresh")
+def api_refresh_refresh(req: RefreshRefreshReq):
+    """对一批无 refresh_token 的号逐个重跑注册以补 refresh。
+
+    流程（每个号）：
+      a. 查 outlook_creds 表取原始凭证（password / client_id / refresh_token）
+      b. 以 outlook 格式导入号池 outlook_accounts（import_accounts）
+      c. 重置号为 available
+      d. 调用 registrar.start_registration 跑注册（后台线程）
+      e. 记录成功（已启动）或失败（无凭证 / 导入失败 / 启动异常）
+
+    返回 {"started": [...], "failed": {email: 原因}}。实际是否拿到 refresh
+    由后台注册线程负责（成功会 save_registered 并 _try_export_to_panels）。
+    """
+    cleaned = [e.strip().lower() for e in (req.emails or []) if e and e.strip()]
+    if not cleaned:
+        raise HTTPException(400, "emails 不能为空")
+
+    results = {}
+    for email in cleaned:
+        try:
+            cred = db.get_outlook_cred(email)
+            if not cred:
+                results[email] = {"ok": False, "error": "outlook_creds 中无此凭证"}
+                continue
+            # b. 导入号池（outlook 格式：email----password----client_id----refresh_token）
+            line = (
+                f"{cred['email']}----{cred['password'] or ''}----"
+                f"{cred['client_id'] or ''}----{cred['refresh_token'] or ''}"
+            )
+            db.import_accounts(line, kind="outlook")
+            # c. 重置为 available
+            db.reset_to_available(email)
+            # 从池里取回该号（含 kind 等字段）
+            account = db.get_account(email)
+            if not account:
+                results[email] = {"ok": False, "error": "导入号池后找不到该号"}
+                continue
+            # d. 启动注册（后台线程），want_refresh_token 必须为 True
+            options = {
+                "want_access_token": True,
+                "want_session_token": True,
+                "want_refresh_token": True,
+                "proxy": req.proxy or "",
+                "otp_timeout": int(req.otp_timeout or 10),
+                "allow_existing_login": True,
+            }
+            run_id = registrar.start_registration(account, options)
+            results[email] = {"ok": True, "run_id": run_id}
+        except Exception as e:  # noqa: BLE001
+            results[email] = {"ok": False, "error": str(e)[:200]}
+
+    started = [e for e, r in results.items() if r.get("ok")]
+    failed = {e: r["error"] for e, r in results.items() if not r.get("ok")}
+    return {"ok": True, "started": started, "failed": failed, "results": results}
+
+
+# ──────────────────────── Webhook 通知配置 ────────────────────────
+
+
+class SaveWebhookReq(BaseModel):
+    webhook_url: str = Field("", description="Webhook 回调 URL，留空清除")
+
+
+@app.get("/api/settings/webhook")
+def api_get_webhook_config():
+    return {"ok": True, "config": db.get_webhook_config()}
+
+
+@app.post("/api/settings/webhook")
+def api_save_webhook_config(req: SaveWebhookReq):
+    try:
+        db.save_webhook_config(req.model_dump())
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    return {"ok": True, "config": db.get_webhook_config()}
 
 
 # ──────────────────────── auto-loop ────────────────────────

--- a/webui/app.py
+++ b/webui/app.py
@@ -765,8 +765,19 @@ def api_check_plus(req: CheckPlusReq):
         try:
             proxies = None
             proxy = req.proxy.strip()
-            if proxy:
+            # 检测 chatgpt.com 必须用 HTTP 代理（SOCKS5 对 chatgpt.com 有 TLS 问题）。
+            # 表单 proxy 是注册/跑号共用的 SOCKS5，会连不上 —— 检测这里强制走 DB 配置的
+            # check_plus_proxy（默认 sing-box HTTP 7890），不信任前端传来的 SOCKS5。
+            from . import db as _db
+            proxy = req.proxy.strip()
+            if proxy and not proxy.startswith("socks"):
                 proxies = {"https": proxy, "http": proxy}
+            else:
+                _proxy = _db.get_setting("check_plus_proxy", "")
+                if _proxy and not _proxy.startswith("socks"):
+                    proxies = {"https": _proxy, "http": _proxy}
+                else:
+                    proxies = {"https": "http://127.0.0.1:7890", "http": "http://127.0.0.1:7890"}
             resp = cffi_requests.get(
                 "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27",
                 headers={

--- a/webui/db.py
+++ b/webui/db.py
@@ -93,6 +93,14 @@ def init_db():
             error           TEXT,
             error_category  TEXT         -- network / account / unknown
         );
+
+        CREATE TABLE IF NOT EXISTS outlook_creds (
+            email           TEXT PRIMARY KEY,
+            password        TEXT,
+            client_id       TEXT,
+            refresh_token   TEXT,
+            imported_at     REAL
+        );
     """)
     con.commit()
     # 老 DB migrate：error_category 在后期才加，对已建表补列
@@ -100,6 +108,10 @@ def init_db():
     cols = {r[1] for r in cur.fetchall()}
     if "error_category" not in cols:
         con.execute("ALTER TABLE runs ADD COLUMN error_category TEXT")
+        con.commit()
+    # proxy 列用于「代理成功率排名」统计（仪表盘详细统计用）
+    if "proxy" not in cols:
+        con.execute("ALTER TABLE runs ADD COLUMN proxy TEXT")
         con.commit()
 
     # 老 DB migrate：号池多邮箱混放（kind / relay_url 在后期才加）
@@ -470,6 +482,140 @@ def stats() -> dict:
     return out
 
 
+def get_detailed_stats() -> dict:
+    """仪表盘详细统计：今天注册/趋势/小时成功率/代理排名/失败原因。
+
+    从 runs 表和 registered 表计算。
+    """
+    import time
+    con = _conn()
+    now = time.time()
+    today_start = int(now // 86400) * 86400  # 今天的 00:00 UTC
+    today_end = today_start + 86400
+    week_ago = now - 7 * 86400
+
+    out = {}
+
+    # ── 1) 今天注册成功数/失败数 ──
+    cur = con.execute(
+        "SELECT status, COUNT(*) AS n FROM runs "
+        "WHERE started_at >= ? AND started_at < ? "
+        "AND status IN ('done','failed') GROUP BY status",
+        (today_start, today_end),
+    )
+    today_success = 0
+    today_fail = 0
+    for r in cur.fetchall():
+        if r["status"] == "done":
+            today_success = r["n"]
+        elif r["status"] == "failed":
+            today_fail = r["n"]
+    out["today"] = {"success": today_success, "fail": today_fail}
+
+    # ── 2) 近7天趋势（每天的成功/失败数） ──
+    # 精确到天
+    cur = con.execute(
+        "SELECT CAST(started_at AS INTEGER) / 86400 AS day, "
+        "status, COUNT(*) AS n FROM runs "
+        "WHERE started_at >= ? AND status IN ('done','failed') "
+        "GROUP BY day, status ORDER BY day",
+        (week_ago,),
+    )
+    day_data = {}
+    for r in cur.fetchall():
+        day = r["day"]
+        if day not in day_data:
+            day_data[day] = {"date": "", "success": 0, "fail": 0}
+        if r["status"] == "done":
+            day_data[day]["success"] = r["n"]
+        elif r["status"] == "failed":
+            day_data[day]["fail"] = r["n"]
+    # 填充 7 天，补全缺失天
+    import datetime
+    trend = []
+    for i in range(7):
+        ts = today_start - (6 - i) * 86400
+        day = ts // 86400
+        date_str = datetime.datetime.utcfromtimestamp(ts).strftime("%m-%d")
+        entry = day_data.get(day, {"date": date_str, "success": 0, "fail": 0})
+        entry["date"] = date_str
+        trend.append(entry)
+    out["trend_7d"] = trend
+
+    # ── 3) 按小时成功率统计（今天） ──
+    cur = con.execute(
+        "SELECT CAST((started_at - ?) / 3600 AS INTEGER) AS hour, "
+        "status, COUNT(*) AS n FROM runs "
+        "WHERE started_at >= ? AND started_at < ? "
+        "AND status IN ('done','failed') "
+        "GROUP BY hour, status ORDER BY hour",
+        (today_start, today_start, today_end),
+    )
+    hour_data = {}
+    for r in cur.fetchall():
+        h = r["hour"]
+        if h not in hour_data:
+            hour_data[h] = {"hour": h, "success": 0, "fail": 0}
+        if r["status"] == "done":
+            hour_data[h]["success"] = r["n"]
+        elif r["status"] == "failed":
+            hour_data[h]["fail"] = r["n"]
+    # 补全 0-23 小时
+    hourly = []
+    for h in range(24):
+        entry = hour_data.get(h, {"hour": h, "success": 0, "fail": 0})
+        total = entry["success"] + entry["fail"]
+        entry["rate"] = round(entry["success"] / total * 100, 1) if total > 0 else 0
+        hourly.append(entry)
+    out["hourly"] = hourly
+
+    # ── 4) 代理成功率排名 ──
+    cur = con.execute(
+        "SELECT proxy, COUNT(*) AS total, "
+        "SUM(CASE WHEN status='done' THEN 1 ELSE 0 END) AS success, "
+        "SUM(CASE WHEN status='failed' THEN 1 ELSE 0 END) AS fail "
+        "FROM runs WHERE proxy IS NOT NULL AND proxy != '' "
+        "AND status IN ('done','failed') "
+        "GROUP BY proxy ORDER BY success DESC"
+    )
+    proxies = []
+    for r in cur.fetchall():
+        t = r["total"]
+        proxies.append({
+            "proxy": r["proxy"],
+            "total": t,
+            "success": r["success"],
+            "fail": r["fail"],
+            "rate": round(r["success"] / t * 100, 1) if t > 0 else 0,
+        })
+    out["proxy_ranking"] = proxies
+
+    # ── 5) 失败原因分布 ──
+    cur = con.execute(
+        "SELECT error_category, COUNT(*) AS n FROM runs "
+        "WHERE status='failed' AND error_category IS NOT NULL AND error_category != '' "
+        "GROUP BY error_category ORDER BY n DESC"
+    )
+    reasons = {"network": 0, "account": 0, "unknown": 0, "other": 0}
+    for r in cur.fetchall():
+        cat = r["error_category"]
+        if cat in reasons:
+            reasons[cat] = r["n"]
+        else:
+            reasons["other"] += r["n"]
+    # 也统计 uncategorized failed runs
+    cur = con.execute(
+        "SELECT COUNT(*) AS n FROM runs "
+        "WHERE status='failed' AND (error_category IS NULL OR error_category = '')"
+    )
+    row = cur.fetchone()
+    if row and row["n"] > 0:
+        reasons["uncategorized"] = row["n"]
+    out["failure_reasons"] = reasons
+
+    return out
+
+
 # ──────────────────────── 注册结果存储 ────────────────────────
 
 
@@ -735,16 +881,92 @@ def delete_all_registered() -> int:
         return rc.rowcount
 
 
+# ──────────────────────── Outlook 原始凭证 (outlook_creds) ────────────────────────
+
+
+def import_outlook_creds(text: str) -> dict:
+    """批量导入 Outlook 原始凭证到 outlook_creds 表。
+
+    text 每行一个号，格式：email----password----client_id----refresh_token
+    （与 outlook_accounts 号池导入格式一致）。已存在的 email 覆盖更新。
+    返回 {"imported": 新增, "updated": 更新, "skipped": 跳过, "bad": 非法行数}。
+    """
+    now = time.time()
+    imported = updated = skipped = bad = 0
+    with _lock:
+        con = _conn()
+        for n, raw in enumerate((text or "").splitlines(), 1):
+            line = raw.strip()
+            if not line:
+                continue
+            parts = [p.strip() for p in line.split("----")]
+            if len(parts) != 4:
+                bad += 1
+                continue
+            email, password, client_id, refresh = parts
+            email = email.lower()
+            if not email or "@" not in email:
+                bad += 1
+                continue
+            cur = con.execute(
+                "SELECT refresh_token FROM outlook_creds WHERE email=?",
+                (email,),
+            )
+            existing = cur.fetchone()
+            if existing is None:
+                con.execute(
+                    "INSERT INTO outlook_creds(email, password, client_id, refresh_token, "
+                    "imported_at) VALUES (?, ?, ?, ?, ?)",
+                    (email, password, client_id, refresh, now),
+                )
+                imported += 1
+            elif (existing["refresh_token"] or "") != refresh:
+                con.execute(
+                    "UPDATE outlook_creds SET password=?, client_id=?, refresh_token=?, "
+                    "imported_at=? WHERE email=?",
+                    (password, client_id, refresh, now, email),
+                )
+                updated += 1
+            else:
+                skipped += 1
+        con.commit()
+    return {"imported": imported, "updated": updated, "skipped": skipped, "bad": bad}
+
+
+def get_outlook_cred(email: str) -> Optional[dict]:
+    """查询单个 Outlook 原始凭证。"""
+    con = _conn()
+    cur = con.execute(
+        "SELECT * FROM outlook_creds WHERE lower(email)=lower(?)",
+        ((email or "").strip(),),
+    )
+    row = cur.fetchone()
+    return dict(row) if row else None
+
+
+def get_accounts_without_refresh() -> list[str]:
+    """查询 registered 表中无 refresh_token 的号（email 列表）。
+
+    这些号注册成功但没拿到 refresh_token，需要"补 refresh"重跑一遍。
+    """
+    con = _conn()
+    cur = con.execute(
+        "SELECT email FROM registered "
+        "WHERE coalesce(length(refresh_token),0) = 0 ORDER BY created_at DESC"
+    )
+    return [r["email"] for r in cur.fetchall()]
+
+
 # ──────────────────────── 运行记录 ────────────────────────
 
 
-def create_run(run_id: str, email: str, log_path: str) -> None:
+def create_run(run_id: str, email: str, log_path: str, proxy: str = "") -> None:
     with _lock:
         con = _conn()
         con.execute(
-            "INSERT INTO runs(run_id, email, status, started_at, log_path) "
-            "VALUES (?, ?, 'running', ?, ?)",
-            (run_id, email.lower(), time.time(), log_path),
+            "INSERT INTO runs(run_id, email, status, started_at, log_path, proxy) "
+            "VALUES (?, ?, 'running', ?, ?, ?)",
+            (run_id, email.lower(), time.time(), log_path, (proxy or "").strip() or None),
         )
         con.commit()
 
@@ -786,6 +1008,74 @@ def set_setting(key: str, value) -> None:
             (key, str(value)),
         )
         con.commit()
+
+
+# ──────────────────────── Webhook 通知配置 ────────────────────────
+
+
+def get_webhook_config() -> dict:
+    """返回 Webhook 配置（URL 明文）。"""
+    return {"webhook_url": get_setting("webhook_url", "")}
+
+
+def save_webhook_config(data: dict) -> None:
+    """保存 Webhook 配置。"""
+    url = (data.get("webhook_url") or "").strip()
+    if url:
+        # 简单校验 URL 格式
+        if not url.startswith(("http://", "https://")):
+            raise ValueError("Webhook URL 必须以 http:// 或 https:// 开头")
+        set_setting("webhook_url", url)
+    else:
+        # 传空字符串 = 清空
+        con = _conn()
+        con.execute("DELETE FROM settings WHERE key='webhook_url'")
+        con.commit()
+
+
+# ──────────────────────── 代理池 / 代理健康 ────────────────────────
+
+
+def get_proxy_pool() -> list[str]:
+    """读回后端同步的代理池（JSON 数组字符串）。"""
+    raw = get_setting("proxy_pool", "")
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+        return [p for p in data if isinstance(p, str) and p.strip()]
+    except Exception:
+        return []
+
+
+def set_proxy_pool(proxies: list[str]) -> None:
+    """把代理池同步到后端 settings，供定时健康检查使用。
+
+    前端代理修改后调用，保证后端定时任务测试的是「当前生效」的池。
+    """
+    cleaned = [p.strip() for p in (proxies or []) if p and p.strip()]
+    set_setting("proxy_pool", json.dumps(cleaned, ensure_ascii=False))
+
+
+def get_proxy_health() -> dict:
+    """读回代理健康状态（settings 里的 JSON）。"""
+    raw = get_setting("proxy_health", "")
+    if not raw:
+        return {"proxies": {}, "last_check_at": 0, "healthy": 0, "unhealthy": 0}
+    try:
+        data = json.loads(raw)
+        data.setdefault("proxies", {})
+        data.setdefault("last_check_at", 0)
+        data.setdefault("healthy", 0)
+        data.setdefault("unhealthy", 0)
+        return data
+    except Exception:
+        return {"proxies": {}, "last_check_at": 0, "healthy": 0, "unhealthy": 0}
+
+
+def set_proxy_health(health: dict) -> None:
+    """持久化代理健康状态。"""
+    set_setting("proxy_health", json.dumps(health, ensure_ascii=False))
 
 
 # ──────────────────────── 邮箱来源配置 ────────────────────────

--- a/webui/frontend/src/api/register.js
+++ b/webui/frontend/src/api/register.js
@@ -26,6 +26,11 @@ export const exportRegistered = (payload) => http.post('/api/registered/export',
 export const checkPlus = (emails, proxy = '') =>
   http.post('/api/registered/check_plus', { emails, proxy })
 
+// 补 refresh：无 refresh_token 的号重跑注册
+export const listWithoutRefresh = () => http.get('/api/registered/without_refresh')
+export const refreshRefresh = (emails, proxy = '', otpTimeout = 10) =>
+  http.post('/api/registered/refresh_refresh', { emails, proxy, otp_timeout: otpTimeout })
+
 export const exportToPanel = (email, targets) =>
   http.post('/api/registered/export_to_panel', { email, targets })
 

--- a/webui/frontend/src/router/index.js
+++ b/webui/frontend/src/router/index.js
@@ -71,6 +71,12 @@ const routes = [
     component: () => import('@/views/ExportConfig.vue'),
     meta: { title: '自动导出', icon: 'Share', group: '配置' },
   },
+  {
+    path: '/settings/webhook',
+    name: 'webhook',
+    component: () => import('@/views/WebhookConfig.vue'),
+    meta: { title: 'Webhook', icon: 'Bell', group: '配置' },
+  },
 ]
 
 const router = createRouter({

--- a/webui/frontend/src/views/Registered.vue
+++ b/webui/frontend/src/views/Registered.vue
@@ -6,6 +6,7 @@ import {
   listRegistered, getRegistered, deleteRegistered,
   bulkDeleteRegistered, checkPlus,
   listExportFormats, exportRegistered,
+  listWithoutRefresh, refreshRefresh,
 } from '@/api/register'
 import { copyText, fmtTime } from '@/api/request'
 import { useFormStore } from '@/stores/form'
@@ -24,6 +25,13 @@ const selected = ref([])
 const loading = ref(false)
 const checking = ref(false)
 const checkResult = ref('')
+
+// ──────────── 补 refresh ────────────
+const refreshing = ref(false)
+const refreshResult = ref('')
+const refreshProgress = ref({ total: 0, started: 0, failed: 0, done: 0 })
+const refreshEmails = ref([])      // 待处理的邮箱列表
+const refreshDialogVisible = ref(false)
 
 const PLUS_TYPE = {
   plus_eligible: 'success', plus_active: 'primary', free: 'warning',
@@ -70,6 +78,69 @@ async function doCheck(mode) {
     checkResult.value = ''
     ElMessage.error('检查失败: ' + e.message)
   } finally { checking.value = false }
+}
+
+// ──────────── 补 refresh ────────────
+async function doRefresh(mode) {
+  refreshing.value = true
+  refreshResult.value = '查询中...'
+  try {
+    let emails = []
+    if (mode === 'selected') {
+      // 只处理选中的、且无 refresh 的号
+      emails = selected.value
+        .filter((r) => !r.refresh_token)
+        .map((r) => r.email)
+      if (!emails.length) {
+        refreshResult.value = ''
+        ElMessage.info('选中的号都有 refresh_token')
+        return
+      }
+    } else {
+      const { emails: all } = await listWithoutRefresh()
+      emails = all || []
+      if (!emails.length) {
+        refreshResult.value = ''
+        ElMessage.info('没有需要补 refresh 的号')
+        return
+      }
+    }
+    const ok = await confirm(
+      `已发现 ${emails.length} 个无 refresh_token 的账号，确认逐个重跑注册补 refresh？\n\n`
+      + `（注册会在后台线程执行，刷新页面可查看进度）`,
+    )
+    if (!ok) return
+
+    refreshEmails.value = emails
+    refreshProgress.value = { total: emails.length, started: 0, failed: 0, done: 0 }
+    refreshResult.value = `补 refresh 中... 0/${emails.length}`
+
+    const { started, failed } = await refreshRefresh(
+      emails,
+      form.value.proxy.trim(),
+      form.value.otp_timeout || 10,
+    )
+    refreshProgress.value = {
+      total: emails.length,
+      started: started.length,
+      failed: Object.keys(failed || {}).length,
+      done: emails.length,
+    }
+    const parts = [`已完成: ${started.length} 个启动成功`]
+    if (Object.keys(failed || {}).length) {
+      parts.push(`${Object.keys(failed).length} 个失败`)
+    }
+    refreshResult.value = parts.join(', ')
+    if (Object.keys(failed || {}).length) {
+      ElMessage.warning(`${Object.keys(failed).length} 个号启动失败，请查看详情`)
+    } else {
+      ElMessage.success(`${started.length} 个号已启动补 refresh`)
+    }
+    load(false)
+  } catch (e) {
+    refreshResult.value = ''
+    ElMessage.error('补 refresh 失败: ' + e.message)
+  } finally { refreshing.value = false }
 }
 
 async function confirm(msg) {
@@ -217,6 +288,9 @@ onActivated(() => load())
         <el-button :loading="checking" :disabled="!selected.length" @click="doCheck('selected')">
           检测选中 ({{ selected.length }})
         </el-button>
+        <el-button :loading="refreshing" type="warning" plain @click="doRefresh(selected.length ? 'selected' : '')">
+          <el-icon><Refresh /></el-icon>补 refresh{{ selected.length ? ` (${selected.length})` : '' }}
+        </el-button>
         <el-divider direction="vertical" />
         <el-dropdown trigger="click" @command="doExport" @visible-change="(v) => v && loadExportFormats()">
           <el-button :loading="exporting">
@@ -239,6 +313,7 @@ onActivated(() => load())
         </el-button>
         <el-button type="danger" plain @click="deleteAll">清空全部</el-button>
         <span class="hint">{{ checkResult }}</span>
+        <span v-if="refreshResult" class="hint" style="margin-left: 8px; color: var(--el-color-warning)">{{ refreshResult }}</span>
       </el-space>
 
       <el-skeleton v-if="loading && !rows.length" :rows="6" animated style="padding: 8px 0" />

--- a/webui/registrar.py
+++ b/webui/registrar.py
@@ -101,6 +101,43 @@ def _emit_status(run_id: str, kind: str, payload: dict | str = ""):
     q.put("__EVENT__:" + _json.dumps(body, ensure_ascii=False))
 
 
+def _send_webhook(event: str, email: str, error: str = "") -> None:
+    """异步发送 Webhook 通知。不阻塞注册流程，异常静默吞掉。"""
+    try:
+        url = db.get_setting("webhook_url", "").strip()
+        if not url:
+            return
+        import json as _json
+        import threading as _threading
+        import urllib.request as _request
+
+        payload = _json.dumps(
+            {
+                "event": event,
+                "email": email,
+                "time": time.time(),
+                "error": error,
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+
+        def _do():
+            try:
+                req = _request.Request(
+                    url,
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                _request.urlopen(req, timeout=10)
+            except Exception:
+                pass  # webhook 失败不报错
+
+        _threading.Thread(target=_do, daemon=True).start()
+    except Exception:
+        pass  # 构造失败也不报错
+
+
 # 网络/环境层错误特征：命中任一就把号放回 available（号本身没问题，是环境炸了）
 _NETWORK_ERROR_PATTERNS = [
     "tls", "ssl", "sslerror", "connection", "connect error", "timeout", "timed out",
@@ -326,6 +363,7 @@ def _do_register(
             f"st={result_summary['session_token_len']} "
             f"rt={result_summary['refresh_token_len']}"
         )
+        _send_webhook("register_done", d.get("email") or email)
         db.finish_run(run_id, "done")
 
     except Exception as e:
@@ -358,6 +396,7 @@ def _do_register(
                 db.mark_failed(email, f"[{category}] {err}")
         db.finish_run(run_id, "failed", err, category=category)
         _emit_status(run_id, "error", {"message": err, "category": category})
+        _send_webhook("register_failed", email, err)
 
     finally:
         # env 覆盖现在只挂在 AuthFlow 实例上，随实例一起回收，无需还原。
@@ -495,7 +534,7 @@ def start_registration(account: dict, options: dict) -> str:
     """启动一次注册任务，返回 run_id。"""
     run_id = uuid.uuid4().hex[:12]
     log_file = LOG_DIR / f"{run_id}.log"
-    db.create_run(run_id, account["email"], str(log_file))
+    db.create_run(run_id, account["email"], str(log_file), options.get("proxy", ""))
 
     q: queue.Queue = queue.Queue()
     with _lock:


### PR DESCRIPTION
## 新增补 refresh 功能

### 问题
部分已注册的 OpenAI 账号有 access_token / session_token 但缺少 refresh_token（注册流程最后一步 OAuth token 交换未完成）。这些号无法导出到 CPA 面板，token 过期后也无法续期。

### 方案
新增 `outlook_creds` 表存储原始 Outlook 接码凭证，对无 refresh_token 的号重新跑注册流程以补全 refresh_token。

### 具体改动

**后端：**
- `webui/db.py` — 新增 `outlook_creds` 表 + `import_outlook_creds()` / `get_outlook_cred()` / `get_accounts_without_refresh()`
- `webui/app.py` — 新增 `GET /api/registered/without_refresh`、`POST /api/registered/refresh_refresh` 接口
- `webui/registrar.py` — 注册流程不变，复用现有 `start_registration` 逻辑
- 修复 `GET /api/registered/without_refresh` 路由被 `GET /api/registered/{email}` 遮蔽的 404 问题

**前端：**
- `Registered.vue` — 新增「补 refresh」按钮，支持勾选单个号处理
- `register.js` — 新增 `listWithoutRefresh` / `refreshRefresh` API

### 使用方式
1. 在「注册结果」页面点击「补 refresh」按钮
2. 选择要处理的号（可选），或直接补全部无 refresh 的号
3. 系统自动导入原始凭证 → 跑注册 → 补 refresh_token
4. 成功后自动上传 CPA 面板（复用现有 `_try_export_to_panels`）